### PR TITLE
Fixed submit button box size in section 2.4.

### DIFF
--- a/slides/02-Developers/03-keyboard.html.md
+++ b/slides/02-Developers/03-keyboard.html.md
@@ -46,7 +46,7 @@ layoutData:
         can tab to the button and press enter to activate it using just the keyboard.
 
       code: |
-        <div class="customButton">
+        <div class="customButton" style="width: 120px;">
           Submit
         </div>
 


### PR DESCRIPTION
Submit button outline is too small for the text in section 2.4.
Added manual pixel width for now since we have to use 'customButton' div instead of a 'button' tag and there is no custom styling for 'customButton'.
