### PR TITLE
Fixed slide 3.2 exercise accepted contrast value

### DIFF
--- a/slides/03-Designers/01-color-contrast.html.md
+++ b/slides/03-Designers/01-color-contrast.html.md
@@ -58,7 +58,7 @@ layout_data:
 
       assertion: |
         assert(
-          dom.querySelector('#contrastValue').innerHTML === '7.05',
+          dom.querySelector('#contrastValue').innerHTML === '7.5',
           "Did you really use the Colour Contrast Check tool? Try again!"
         );
 ---


### PR DESCRIPTION
The contrast value accepted in the exercise was originally 7.05, which is incorrect according to the 2 programs the slide asks the reader to use. The correct contrast value is 7.5.
