### PR TITLE
Changed second example on slide 2.6 to be consistent with first

### DIFF
--- a/slides/02-Developers/05-list.html.md
+++ b/slides/02-Developers/05-list.html.md
@@ -59,9 +59,9 @@ layout_data:
 
       code: |
         <div>
-          <span>A house of straw</span>
-          <span>A house of sticks</span>
-          <span>A house of bricks</span>
+          <div>A house of straw</div>
+          <div>A house of sticks</div>
+          <div>A house of bricks</div>
         </div>
 
       assertion: |


### PR DESCRIPTION
change also makes it easier to identify individual list items from the preview (span->div)
