### PR TITLE
slide 2.9 fixed landmarks number to follow voiceover menu

### DIFF
--- a/slides/02-Developers/09-aria.html.md
+++ b/slides/02-Developers/09-aria.html.md
@@ -42,7 +42,7 @@ layout_data:
       assertion: |
         var link = document.getElementById('landmarks');
         assert(
-          link.value === '3' || link.value === 'three',
+          link.value === '4' || link.value === 'four',
           "That is not the right number of landmarks on the page!"
         );
 


### PR DESCRIPTION
ctrl-opt-u pulls up a new menu screen. On this screen there are 4 landmarks related to the page. However the page only allows 3 landmarks as the correct answer. This problem has been resolved.
