### PR TITLE
Changes Telephone input type in slide 2.5 from number to text

### DIFF
--- a/slides/02-Developers/04-labels.html.md
+++ b/slides/02-Developers/04-labels.html.md
@@ -72,9 +72,9 @@ layout_data:
       code: |
         <fieldset>
           <legend>Telephone</legend>
-          <input id="one" type="number" aria-label="Area Code">
-          <input type="number" aria-label="Exchange Code">
-          <input type="number" aria-label="Line Number">
+          <input id="one" type="text" aria-label="Area Code">
+          <input type="text" aria-label="Exchange Code">
+          <input type="text" aria-label="Line Number">
         </fieldset>
 
     - title: Using 'aria-describedby'


### PR DESCRIPTION
When a user selected a Telephone input box in slide 2.5 section 'Using aria-label' and attempted to scroll horizontally, the numbers in that input box changed rather than the page scrolling. To fix this, the input type has been set to "text" rather than "number".
