### PR TITLE
Fixed bug in "Using area-label" code so VoiceOver will read correct l…

### DIFF
--- a/slides/02-Developers/04-labels.html.md
+++ b/slides/02-Developers/04-labels.html.md
@@ -70,12 +70,12 @@ layout_data:
         using a screen reader. We can provide contextual detail with `aria-label`.
 
       code: |
-        <fieldset>
-          <legend>Telephone</legend>
+        <div role="group" aria-labelledby="groupLabel">
+          <span id="groupLabel">Telephone</span>
           <input id="one" type="number" aria-label="Area Code">
           <input type="number" aria-label="Exchange Code">
           <input type="number" aria-label="Line Number">
-        </fieldset>
+        </div>
 
     - title: Using 'aria-describedby'
       description: |


### PR DESCRIPTION
When using VoiceControl on Chome on a Mac, I was sometimes having issues with the textboxes reading the correct title and instead reading the rest of the page as the title. I changed the default code to say the correct label title. 
