### PR TITLE
Increase size of menu expand/collapse icons on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -193,4 +193,12 @@ body {
   #exerslide-main {
     overflow-x: hidden;
   }
+
+  .fa-bars{
+      font-size: 2em;
+  }
+
+  .fa-chevron-left{
+      font-size: 2em;
+  }
 }


### PR DESCRIPTION
Increased from 1.33em to 2em in order to make them easer to tap.
