### PR TITLE
Ensuring "Editor Output" box widths under 2.5 Labels are all consistent

### DIFF
--- a/slides/02-Developers/04-labels.html.md
+++ b/slides/02-Developers/04-labels.html.md
@@ -21,6 +21,11 @@ style: |
     #dateFormat {
       font-size: 13px;
     }
+    
+    #telephone input {
+      width: 90px;
+      display: block;
+    }
 
 layout_data:
   examples:
@@ -70,11 +75,11 @@ layout_data:
         using a screen reader. We can provide contextual detail with `aria-label`.
 
       code: |
-        <fieldset>
+        <fieldset id="telephone">
           <legend>Telephone</legend>
-          <input id="one" type="number" aria-label="Area Code">
-          <input type="number" aria-label="Exchange Code">
-          <input type="number" aria-label="Line Number">
+          <input id="one" type="text" aria-label="Area Code">
+          <input type="text" aria-label="Exchange Code">
+          <input type="text" aria-label="Line Number">
         </fieldset>
 
     - title: Using 'aria-describedby'


### PR DESCRIPTION
I initially changed the type of the input fields to "text" to follow PR#34's changes. The 'Editor Output' box has a width that is different from the six other boxes on the page, which is an inconsistency in the webpage's design. To resolve this issue, I used style to change the input fields' size to be less than the default width of the box to ensure that the wide input fields did not expand the width of the box.
