### PR TITLE
Change raw URLs to hyperlinks

### DIFF
--- a/slides/00-Introduction/01-faqs.md
+++ b/slides/00-Introduction/01-faqs.md
@@ -19,16 +19,15 @@ The tutorial should work with most assistive technologies, but Apple's VoiceOver
 **Where can I find more information on accessibility?**
 
 Here are a few resources to get you started:
-- Web Content Accessibility Guidelines: <https://www.w3.org/WAI/intro/wcag>
-- WebAIM: <http://webaim.org/>
+- [Web Content Accessibility Guidelines](https://www.w3.org/WAI/intro/wcag)
+- [WebAIM](http://webaim.org/)
 
 **What are some good, free, developer tools for accessibility?**
 
-- WAVE by WebAIM for general website accessibility: <http://wave.webaim.org/>
-- Juicy Studio's Readability Test: 
-<http://juicystudio.com/services/readability.php>
-- Vischeck's Color Blindness Checker: <http://www.vischeck.com/>
+- [WAVE by WebAIM for general website accessibility](http://wave.webaim.org/)
+- [Juicy Studio's Readability Test](http://juicystudio.com/services/readability.php)
+- [Vischeck's Color Blindness Checker](http://www.vischeck.com/)
 
 **Are there jobs in the field of accessibility?**
 
-Definitely, and the industry is growing. Take a look here: <https://twitter.com/a11yjobs>
+Definitely, and the industry is growing. Take a look [here](https://twitter.com/a11yjobs).

--- a/slides/02-Developers/10-checklist.md
+++ b/slides/02-Developers/10-checklist.md
@@ -16,7 +16,6 @@ We've covered a bunch of ground related to accessible software development. One 
 
 There are also a number of free tools available for assessing the accessibility:
 
-- WAVE by WebAIM for general website accessibility: <http://wave.webaim.org/>
-- Juicy Studio's Readability Test: 
-<http://juicystudio.com/services/readability.php>
-- Vischeck's Color Blindness Checker: <http://www.vischeck.com/>
+- [WAVE by WebAIM for general website accessibility](http://wave.webaim.org/)
+- [Juicy Studio's Readability Test](http://juicystudio.com/services/readability.php)
+- [Vischeck's Color Blindness Checker](http://www.vischeck.com/)

--- a/slides/03-Designers/05-photos.md
+++ b/slides/03-Designers/05-photos.md
@@ -12,11 +12,11 @@ While alt-text can make a static photo or graphic accessible to screen reader us
 When providing video, via either an embedded or standalone video player, the controls of that player need to be operable by a keyboard-only user (i.e., without a mouse). Controls such as play, pause, fast forward, rewind and scrub bars and closed caption buttons all need to be labeled properly and available to a screen reader user in the same way any web page is made accessible.
 
 "Audio description" (also known as "video description") provides an added narrative track that describes key visual elements of a animation or video or movie. Timed to be heard during pauses in dialog, descriptions can be recorded and synchronized with the video or made available as text to be read by a screen reader. With HTML5 video players and the video and track elements, audio descriptions can even be heard while a video is automatically paused. For more on how to deliver descriptions, see the following resources:
-- <http://webaim.org/techniques/captions/>
-- <https://www.w3.org/WAI/GL/wiki/Using_the_track_element_to_provide_audio_descriptions>
-- <http://www.ssbbartgroup.com/blog/cvaa-video-programming-requirements-video-description/>
+- [Captions](http://webaim.org/techniques/captions/)
+- [Providing Audio Descriptions](https://www.w3.org/WAI/GL/wiki/Using_the_track_element_to_provide_audio_descriptions)
+- [Providing Video Descriptions](http://www.ssbbartgroup.com/blog/cvaa-video-programming-requirements-video-description/)
 
 Closed captioning involves the addition of text to synchronized to a video's audio by either embedding caption data in your video or adding a "sidecar" closed caption file to your server. There are a variety of caption formats used by content providers as well as tools for creating captions. Many vendors are available to provide captions in the format that works for your video player's needs. Resources for captioning media:
 
-- <http://webaim.org/techniques/captions/>
-- <http://info.3playmedia.com/wp-best-practices.html>
+- [Captioning Technique](http://webaim.org/techniques/captions/)
+- [Best Practices](http://info.3playmedia.com/wp-best-practices.html)

--- a/slides/03-Designers/06-checklist.md
+++ b/slides/03-Designers/06-checklist.md
@@ -15,6 +15,6 @@ We've covered a bunch of ground related to improving the accessibility of visual
 
 There are also a number of free tools available for assessing the accessibility:
 
-- WAVE by WebAIM for general website accessibility: <http://wave.webaim.org/>
-- Juicy Studio's Readability Test: <http://juicystudio.com/services/readability.php>
-- Vischeck's Color Blindness Checker: <http://www.vischeck.com/>
+- [WAVE by WebAIM for general website accessibility](http://wave.webaim.org/)
+- [Juicy Studio's Readability Test](http://juicystudio.com/services/readability.php)
+- [Vischeck's Color Blindness Checker](http://www.vischeck.com/)


### PR DESCRIPTION
- Certain slides (1.2, 2.11, 3.6, 3.7) display raw URL links rather than text hyperlinks
- Added hyperlinks to make for slightly more fluid reading
- Adds semantic clarity to the intent of the link
