### PR TITLE
Changes to add accessibility instructions for Windows users

### DIFF
--- a/slides/00-Introduction/00-instructions.md
+++ b/slides/00-Introduction/00-instructions.md
@@ -20,7 +20,20 @@ use the verify button to check whether your solution is correct.
 
 4. When verifying with VoiceOver, use Chrome on a Mac for the best experience. However, the "Verify" button provided after each exercise will work with any browser/OS combination.
 
-5. ARIA stands for Accessible Rich Internet Applications, a W3C standard for 
+5. If you are using this tutorial on a Windows 7/8/10 operating system, you can use Windows Narrator instead. Here are some instructions for navigating with Narrator:
+	* <kbd>Windows</kbd> + <kbd>Enter</kbd> turns Narrator on/off
+	* <kbd>Ctrl</kbd> stops reading
+	* <kbd>Caps Lock</kbd> + <kbd>Right arrow</kbd> moves to next item
+	* <kbd>Caps Lock</kbd> + <kbd>Left arrow</kbd> moves to previous item
+	* <kbd>Caps Lock</kbd> + <kbd>O</kbd> reads next line
+	* <kbd>Caps Lock</kbd> + <kbd>P</kbd> reads next word
+	* <kbd>Caps Lock</kbd> + <kbd>{</kbd> reads next character
+	* <kbd>Caps Lock</kbd> + <kbd>J</kbd> jumps to next heading
+	* <kbd>Caps Lock</kbd> + <kbd>L</kbd> jumps to next link
+	* If you are looking for more commands, you can hit <kbd>Caps Lock</kbd> + <kbd>F1</kbd> to show a list of all commands,
+		or <kbd>Caps Lock</kbd> + <kbd>F2</kbd> to show a list of all commands for the current item.
+
+6. ARIA stands for Accessible Rich Internet Applications, a W3C standard for 
    building accessible user interfaces on the web.
 
 Happy learning! <i class="fa fa-smile-o"><i class="accessible_elem">Smiley Icon</i></i>

--- a/slides/02-Developers/01-headings.html.md
+++ b/slides/02-Developers/01-headings.html.md
@@ -20,14 +20,15 @@ layout_data:
         The heading below is a real heading and uses an `<h3>` tag. If you are on a
         Mac, turn on VoiceOver with <kbd>Cmd</kbd> + <kbd>F5</kbd> and then press
         <kbd>Ctrl</kbd> + <kbd>Opt</kbd> + <kbd>Cmd</kbd> + <kbd>h</kbd> to jump to
-        a heading.
+        a heading. If you are using Windows 7/8/10, turn on Narrator with <kbd>Windows</kbd> + <kbd>Enter</kbd>
+        and then press <kbd>Caps Lock</kbd> + <kbd>J</kbd> to jump to a heading.
       code: |
         <h3>A real heading</h3>
     - title: Unsemantic Heading exercise
       description: |
         The heading below is a fake heading made to look like a heading with an
         unsemantic `<div>`. Change the `<div>` below to use an `<h3>` tag. Now verify your semantic heading using the Verify button as well as
-        with VoiceOver.
+        with VoiceOver/Narrator.
       code: |
         <div class="fakeHeading">
           A fake heading

--- a/slides/02-Developers/02-images.html.md
+++ b/slides/02-Developers/02-images.html.md
@@ -9,7 +9,9 @@ layout_data:
       description: |
         This is an image with an alt text. Turn on VoiceOver if you are on a Mac, tab
         to the Editor Output section, and use <kbd>Ctrl</kbd> + <kbd>Opt</kbd> + <kbd>Right Arrow</kbd>
-        to navigate to these images. VoiceOver will announce the alt text. For the second image below, VoiceOver
+        to navigate to these images. If you are on Windows 7/8/10, the same process can be followed by turning on Narrator with 
+        <kbd>Windows</kbd> + <kbd>Enter</kbd> and using <kbd>Caps Lock</kbd> + <kbd>Right Arrow</kbd> to navigate to the images.
+        VoiceOver/Narrator will announce the alt text. For the second image below, VoiceOver/Narrator
         will not announce anything meaningful since there is no alt text.
       code: |
         <img
@@ -19,8 +21,8 @@ layout_data:
 
     - title: Inaccessible Inline Image exercise
       description: |
-        This is an image without alt text. Turn on VoiceOver and listen to how it is read. Add an `alt`
-        attribute "Facebook logo" to this image to make it accessible and test it again with VoiceOver.
+        This is an image without alt text. Turn on VoiceOver/Narrator and listen to how it is read. Add an `alt`
+        attribute "Facebook logo" to this image to make it accessible and test it again with VoiceOver/Narrator.
       code: |
         <img
           src="./images/inline-image.png"

--- a/slides/02-Developers/05-list.html.md
+++ b/slides/02-Developers/05-list.html.md
@@ -23,7 +23,15 @@ layout_data:
 
         3. Press <kbd>Ctrl</kbd> + <kbd>Opt</kbd> + <kbd>Right Arrow</kbd>.
 
-        VoiceOver will announce 'List 3 items'.
+        If you are on Windows 7/8/10, you can follow the following alternate instructions:
+
+        1. Turn on Narrator with <kbd>Windows</kbd> + <kbd>Enter</kbd>.
+
+        2. Press <kbd>Caps Lock</kbd> + <kbd>J</kbd> repeatedly until you have jumped to the Editor Output heading.
+
+        3. Press <kbd>Caps Lock</kbd> + <kbd>Right Arrow</kbd>.
+
+        VoiceOver/Narrator will announce 'List 3 items'.
 
       code: |
         <ul>

--- a/slides/02-Developers/07-tables.html.md
+++ b/slides/02-Developers/07-tables.html.md
@@ -61,6 +61,11 @@ layout_data:
         1. Press <kbd>Ctrl</kbd> + <kbd>Opt</kbd> + <kbd>Cmd</kbd> + <kbd>h</kbd> repeatedly until you reach the Editor Output region.
         2. Now press <kbd>Ctrl</kbd> + <kbd>Opt</kbd> + <kbd>Right Arrow</kbd> repeatedly to navigate the table cells.
 
+        To test the table below with Narrator:
+
+        1. Press <kbd>Caps Lock</kbd> + <kbd>J</kbd> repeatedly until you reach the Editor Output region.
+        2. Now press <kbd>Caps Lock</kbd> + <kbd>Right Arrow</kbd> repeatedly to navigate the table cells.
+
         At this time, VoiceOver does not read the column headers in Chrome. However, VoiceOver does read them in Safari. Windows screen readers typically read column and row headers as well.
 
       code: |


### PR DESCRIPTION
These changes were made in order to provide those using Windows 7/8/10 with the equivalent instructions to match up with the instructions given for Mac users. This should allow the majority of users to follow the tutorial appropriately, whereas before Windows users would have been unable to follow many of the instructions.
