### PR TITLE
Changed single quotes around "search" to double for consistency

### DIFF
--- a/slides/02-Developers/04-labels.html.md
+++ b/slides/02-Developers/04-labels.html.md
@@ -96,7 +96,7 @@ layout_data:
 
     - title: Inaccessible Button exercise
       description: |
-        Add an `aria-label` to the button below and label it 'search' to
+        Add an `aria-label` to the button below and label it "search" to
         make it accessible.
 
       code: |


### PR DESCRIPTION
Changed single quotes around "search" to double for consistency and differentiate it with the use of single quotes in other places of the tutorial to avoid confusion.
