### PR TITLE
1.1 Using this Tutorial: changed instruction 4 from use Chrome on Mac…

### DIFF
--- a/slides/00-Introduction/00-instructions.md
+++ b/slides/00-Introduction/00-instructions.md
@@ -18,7 +18,7 @@ use the verify button to check whether your solution is correct.
     (repeatedly) navigates by headings
     <br/><br/>
 
-4. When verifying with VoiceOver, use Chrome on a Mac for the best experience. However, the "Verify" button provided after each exercise will work with any browser/OS combination.
+4. When verifying with VoiceOver, use Chrome on a Mac. However, the "Verify" button provided after each exercise will work with any browser/OS combination.
 
 5. ARIA stands for Accessible Rich Internet Applications, a W3C standard for 
    building accessible user interfaces on the web.


### PR DESCRIPTION
changed instruction 4 on 1.1 Using this Tutorial from 'use Chrome on Mac for best experience' to 'use Chrome on Mac', in order to reduce reader confusion and to prevent someone from trying to use VoiceOver on Firefox.
