### PR TITLE
Added ARIA label for smiley icon on introduction page

### DIFF
--- a/slides/00-Introduction/00-instructions.md
+++ b/slides/00-Introduction/00-instructions.md
@@ -23,4 +23,4 @@ use the verify button to check whether your solution is correct.
 5. ARIA stands for Accessible Rich Internet Applications, a W3C standard for 
    building accessible user interfaces on the web.
 
-Happy learning! <i class="fa fa-smile-o"><i class="accessible_elem">Smiley Icon</i></i>
+Happy learning! <i class="fa fa-smile-o" aria-label="Smiley icon"><i class="accessible_elem">Smiley Icon</i></i>


### PR DESCRIPTION
Fixes issue with Chrome 53.0.2785.101 (64-bit) on OS X 10.11.6 where VoiceOver just displays a question mark and says nothing indicative of the content when reading over the smiley face icon at the end of the introduction page.
