### PR TITLE
Fix missing example in 3.4:Text Size

### DIFF
--- a/slides/03-Designers/03-text.html.md
+++ b/slides/03-Designers/03-text.html.md
@@ -42,6 +42,7 @@ layoutData:
         will notice that the words bleed outside the box below. Try fixing this example
         by specifying the width and height as relative units, such as ems. Set the height
         to 3em and width to 10em and verify your answers.
+        Example: `style="height:3em; width:10em"`.
 
       code: |
         <div


### PR DESCRIPTION
In the previous version, it does not have the example of how to add height and width style, now I add an example to tell the user how to change the style in html code
